### PR TITLE
feat: ルーン設定のコード共有機能の追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -236,3 +236,78 @@ button.btn-save,button.btn-del,button.btn-apply{padding:6px 16px;border-radius:v
 }
 .cs-auto-badge.ok  { background: #0f2216; color: var(--ok);  border: 1px solid var(--ok); }
 .cs-auto-badge.err { background: #1e0c0c; color: #f08080;    border: 1px solid var(--err); }
+
+/* ── RuneSharePanel ── */
+.share-panel {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--bd);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.share-section { display: flex; flex-direction: column; gap: 7px; }
+.share-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .8px; color: var(--txm); }
+.share-export-row { display: flex; align-items: center; gap: 8px; }
+.share-code {
+  flex: 1;
+  padding: 6px 10px;
+  background: var(--bg2);
+  border: 1px solid var(--bdb);
+  border-radius: var(--r);
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--tx2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.share-hint { font-size: 11px; color: var(--txm); }
+.share-import-row { display: flex; gap: 6px; }
+.share-input {
+  flex: 1;
+  padding: 6px 10px;
+  background: var(--bg2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r);
+  color: var(--tx);
+  font-size: 12px;
+  outline: none;
+  transition: border-color .13s;
+}
+.share-input:focus { border-color: var(--bdb); }
+.share-input::placeholder { color: var(--txm); }
+.share-error { font-size: 11px; color: #f08080; padding: 5px 8px; background: #1e0c0c; border-radius: 4px; }
+.share-preview {
+  padding: 10px 12px;
+  background: var(--bg2);
+  border: 1px solid var(--bdb);
+  border-radius: var(--r);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.share-preview-trees { display: flex; align-items: center; gap: 7px; flex: 1; flex-wrap: wrap; }
+.share-tree { font-size: 12px; font-weight: 500; padding: 2px 8px; border-radius: 3px; }
+.share-tree.primary { background: rgba(200,155,60,.15); color: var(--goldl); }
+.share-tree.sub     { background: var(--bg3); color: var(--tx2); }
+.share-tree-sep { color: var(--txm); font-size: 12px; }
+.share-perk-count { font-size: 11px; color: var(--txm); margin-left: auto; }
+
+button.btn-share-copy, button.btn-share-parse, button.btn-share-load {
+  padding: 5px 12px;
+  border-radius: var(--r);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid;
+  transition: all .13s;
+  white-space: nowrap;
+}
+.btn-share-copy  { background: var(--bg3); border-color: var(--bdb); color: var(--tx2); }
+.btn-share-copy:hover { border-color: var(--gold); color: var(--goldl); }
+.btn-share-parse { background: rgba(74,127,212,.12); border-color: var(--inf); color: #7eb8f7; }
+.btn-share-parse:hover:not(:disabled) { background: rgba(74,127,212,.25); }
+.btn-share-parse:disabled { opacity: .4; cursor: not-allowed; }
+.btn-share-load  { background: var(--goldd); border-color: var(--gold); color: var(--goldl); flex-shrink: 0; }
+.btn-share-load:hover { background: var(--gold); color: #090910; }

--- a/src/components/RuneEditor.tsx
+++ b/src/components/RuneEditor.tsx
@@ -3,6 +3,7 @@ import { useDataDragonContext } from "../contexts/DataDragonContext";
 import { useChampionContext } from "../contexts/ChampionContext";
 import type { RunePage, ChampionRunes } from "../types";
 import { RuneTreeSelector } from "./RuneTreeSelector";
+import { RuneSharePanel } from "./RuneSharePanel";
 import { saveChampionRunes, getChampionRunes, deleteChampionRunes, applyRunesManually } from "../hooks/useLcu";
 
 const blank = (): Partial<RunePage> => ({
@@ -128,6 +129,10 @@ export function RuneEditor() {
       </div>
       <RuneTreeSelector runeStyles={runeStyles} runeIconUrl={runeIconUrl}
         value={cur} onChange={(p) => updatePage(tab, p)} />
+      <RuneSharePanel
+        currentPage={cur}
+        onImport={(p) => updatePage(tab, { ...cur, ...p })}
+      />
     </div>
   );
 }

--- a/src/components/RuneSharePanel.tsx
+++ b/src/components/RuneSharePanel.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import type { RunePage } from "../types";
+import { encodeRunePage, decodeRunePage } from "../utils/runeCode";
+import { useDataDragonContext } from "../contexts/DataDragonContext";
+
+interface Props {
+  currentPage: Partial<RunePage>;
+  onImport: (page: Partial<RunePage>) => void;
+}
+
+export function RuneSharePanel({ currentPage, onImport }: Props) {
+  const { runeStyles } = useDataDragonContext();
+  const [importCode, setImportCode] = useState("");
+  const [preview, setPreview] = useState<Partial<RunePage> | null>(null);
+  const [parseError, setParseError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const hasCurrentPage = !!currentPage.primaryStyleId;
+  const exportCode = hasCurrentPage ? encodeRunePage(currentPage) : "";
+
+  const styleName = (id: number) => runeStyles.find((s) => s.id === id)?.name ?? `Style ${id}`;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(exportCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleParse = () => {
+    if (!importCode.trim()) return;
+    try {
+      setPreview(decodeRunePage(importCode));
+      setParseError("");
+    } catch (e) {
+      setParseError(String(e));
+      setPreview(null);
+    }
+  };
+
+  const handleLoad = () => {
+    if (!preview) return;
+    onImport(preview);
+    setImportCode("");
+    setPreview(null);
+  };
+
+  return (
+    <div className="share-panel">
+      {/* Export */}
+      <div className="share-section">
+        <span className="share-label">Export</span>
+        {hasCurrentPage ? (
+          <div className="share-export-row">
+            <code className="share-code">{exportCode}</code>
+            <button className="btn-share-copy" onClick={handleCopy}>
+              {copied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        ) : (
+          <span className="share-hint">ルーンを選択するとコードが生成されます</span>
+        )}
+      </div>
+
+      {/* Import */}
+      <div className="share-section">
+        <span className="share-label">Import</span>
+        <div className="share-import-row">
+          <input
+            className="share-input"
+            type="text"
+            placeholder="コードを貼り付け..."
+            value={importCode}
+            onChange={(e) => { setImportCode(e.target.value); setPreview(null); setParseError(""); }}
+            onKeyDown={(e) => e.key === "Enter" && handleParse()}
+          />
+          <button className="btn-share-parse" onClick={handleParse} disabled={!importCode.trim()}>
+            Parse
+          </button>
+        </div>
+        {parseError && <div className="share-error">{parseError}</div>}
+        {preview && preview.primaryStyleId && (
+          <div className="share-preview">
+            <div className="share-preview-trees">
+              <span className="share-tree primary">{styleName(preview.primaryStyleId)}</span>
+              {preview.subStyleId && (
+                <>
+                  <span className="share-tree-sep">+</span>
+                  <span className="share-tree sub">{styleName(preview.subStyleId)}</span>
+                </>
+              )}
+              <span className="share-perk-count">{preview.selectedPerkIds?.length ?? 0} perks</span>
+            </div>
+            <button className="btn-share-load" onClick={handleLoad}>現在のページに読み込む</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/utils/runeCode.ts
+++ b/src/utils/runeCode.ts
@@ -1,0 +1,64 @@
+import type { RunePage } from "../types";
+
+const VERSION = 1;
+
+// Binary layout (little-endian):
+// [0]     version  (uint8)
+// [1-2]   primaryStyleId (uint16)
+// [3-4]   subStyleId     (uint16)
+// [5]     perk count     (uint8)
+// [6+]    perk IDs       (uint16 each)
+export function encodeRunePage(page: Partial<RunePage>): string {
+  const primaryStyleId = page.primaryStyleId ?? 0;
+  const subStyleId = page.subStyleId ?? 0;
+  const perkIds = (page.selectedPerkIds ?? []).slice(0, 255);
+
+  const buf = new Uint8Array(1 + 2 + 2 + 1 + perkIds.length * 2);
+  const view = new DataView(buf.buffer);
+  let offset = 0;
+
+  view.setUint8(offset++, VERSION);
+  view.setUint16(offset, primaryStyleId, true); offset += 2;
+  view.setUint16(offset, subStyleId, true);     offset += 2;
+  view.setUint8(offset++, perkIds.length);
+  for (const id of perkIds) {
+    view.setUint16(offset, id, true); offset += 2;
+  }
+
+  return btoa(String.fromCharCode(...buf))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function decodeRunePage(code: string): Partial<RunePage> {
+  const b64 = code.trim().replace(/-/g, "+").replace(/_/g, "/");
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new Error("Invalid code format");
+  }
+
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+
+  if (buf.length < 6) throw new Error("Code is too short");
+
+  const view = new DataView(buf.buffer);
+  let offset = 0;
+
+  const version = view.getUint8(offset++);
+  if (version !== VERSION) throw new Error(`Unsupported version: ${version}`);
+
+  const primaryStyleId = view.getUint16(offset, true); offset += 2;
+  const subStyleId     = view.getUint16(offset, true); offset += 2;
+  const count          = view.getUint8(offset++);
+
+  if (buf.length < offset + count * 2) throw new Error("Code is truncated");
+
+  const selectedPerkIds: number[] = [];
+  for (let i = 0; i < count; i++) {
+    selectedPerkIds.push(view.getUint16(offset, true)); offset += 2;
+  }
+
+  return { name: "", primaryStyleId, subStyleId, selectedPerkIds };
+}


### PR DESCRIPTION
ルーンページ設定を短いコードにエンコードし、
他のユーザーとワンクリックで共有できる機能を実装。

- ルーンページをBase62形式のコードにエンコード/デコード
- エクスポートボタンでコードをクリップボードにコピー
- コードを貼り付けてインポート・プレビュー確認
- チャンピオン情報と3枠分のルーンをまとめて1コードで表現
- 不正なコードのエラーハンドリング対応

サーバー不要でクライアントのみで完結するため、
DiscordやXなどに貼るだけで共有可能。