### PR TITLE
feat: キャラ+レーン別ルーン管理の実装

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-﻿use tauri::AppHandle;
+use tauri::AppHandle;
 use tauri_plugin_store::StoreExt;
 use serde_json::json;
 
@@ -10,11 +10,23 @@ use crate::lcu::{
 const STORE_FILE: &str = "runes.json";
 const RUNES_KEY: &str = "champion_runes";
 
-pub fn get_saved_runes(app: &AppHandle, champion_id: i64) -> Option<ChampionRunes> {
+/// チャンピオン+レーンで検索し、未登録時はチャンピオンのみでフォールバック
+pub fn get_saved_runes(app: &AppHandle, champion_id: i64, lane: Option<&str>) -> Option<ChampionRunes> {
     let store = app.store(STORE_FILE).ok()?;
     let all: Vec<ChampionRunes> = store.get(RUNES_KEY)
         .and_then(|v| serde_json::from_value(v).ok())
         .unwrap_or_default();
+
+    // 1. チャンピオン+レーン 完全一致
+    if let Some(lane) = lane {
+        if let Some(found) = all.iter().find(|r| {
+            r.champion_id == champion_id && r.lane.as_deref() == Some(lane)
+        }) {
+            return Some(found.clone());
+        }
+    }
+
+    // 2. フォールバック: チャンピオンのみ（レーンなし or 任意）
     all.into_iter().find(|r| r.champion_id == champion_id)
 }
 
@@ -41,7 +53,10 @@ pub async fn save_champion_runes(
     let mut all: Vec<ChampionRunes> = store.get(RUNES_KEY)
         .and_then(|v| serde_json::from_value(v).ok())
         .unwrap_or_default();
-    if let Some(ex) = all.iter_mut().find(|r| r.champion_id == champion_runes.champion_id) {
+    // championId + lane の複合キーで一致するものを更新
+    if let Some(ex) = all.iter_mut().find(|r| {
+        r.champion_id == champion_runes.champion_id && r.lane == champion_runes.lane
+    }) {
         *ex = champion_runes;
     } else {
         all.push(champion_runes);
@@ -54,12 +69,13 @@ pub async fn save_champion_runes(
 pub async fn get_champion_runes(
     app: AppHandle,
     champion_id: i64,
+    lane: Option<String>,
 ) -> Result<Option<ChampionRunes>, String> {
     let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
     let all: Vec<ChampionRunes> = store.get(RUNES_KEY)
         .and_then(|v| serde_json::from_value(v).ok())
         .unwrap_or_default();
-    Ok(all.into_iter().find(|r| r.champion_id == champion_id))
+    Ok(all.into_iter().find(|r| r.champion_id == champion_id && r.lane == lane))
 }
 
 #[tauri::command]
@@ -71,20 +87,28 @@ pub async fn get_all_champion_runes(app: AppHandle) -> Result<Vec<ChampionRunes>
 }
 
 #[tauri::command]
-pub async fn delete_champion_runes(app: AppHandle, champion_id: i64) -> Result<(), String> {
+pub async fn delete_champion_runes(
+    app: AppHandle,
+    champion_id: i64,
+    lane: Option<String>,
+) -> Result<(), String> {
     let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
     let mut all: Vec<ChampionRunes> = store.get(RUNES_KEY)
         .and_then(|v| serde_json::from_value(v).ok())
         .unwrap_or_default();
-    all.retain(|r| r.champion_id != champion_id);
+    all.retain(|r| !(r.champion_id == champion_id && r.lane == lane));
     store.set(RUNES_KEY, json!(all));
     store.save().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub async fn apply_runes_manually(app: AppHandle, champion_id: i64) -> Result<(), String> {
+pub async fn apply_runes_manually(
+    app: AppHandle,
+    champion_id: i64,
+    lane: Option<String>,
+) -> Result<(), String> {
     let client = LcuClient::from_lockfile().map_err(|e| e.to_string())?;
-    let runes = get_saved_runes(&app, champion_id)
+    let runes = get_saved_runes(&app, champion_id, lane.as_deref())
         .ok_or_else(|| format!("No runes for champion {}", champion_id))?;
     apply_champion_runes(&client, &runes).await.map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lcu/runes.rs
+++ b/src-tauri/src/lcu/runes.rs
@@ -19,6 +19,8 @@ pub struct ChampionRunes {
     pub champion_id: i64,
     #[serde(rename = "championName")]
     pub champion_name: String,
+    #[serde(default)]
+    pub lane: Option<String>,
     pub pages: Vec<RunePage>,
 }
 

--- a/src-tauri/src/lcu/watcher.rs
+++ b/src-tauri/src/lcu/watcher.rs
@@ -1,4 +1,4 @@
-﻿use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
 use tauri::{AppHandle, Emitter};
@@ -9,6 +9,29 @@ use super::runes::apply_champion_runes;
 use crate::commands::get_saved_runes;
 
 static LAST_CHAMP: AtomicI64 = AtomicI64::new(0);
+static LAST_LANE: AtomicI64 = AtomicI64::new(0);
+
+fn lane_to_id(lane: Option<&str>) -> i64 {
+    match lane {
+        Some("top") => 1,
+        Some("jungle") => 2,
+        Some("mid") => 3,
+        Some("bot") => 4,
+        Some("support") => 5,
+        _ => 0,
+    }
+}
+
+fn lcu_position_to_lane(pos: &str) -> Option<String> {
+    match pos.to_uppercase().as_str() {
+        "TOP" => Some("top".to_string()),
+        "JUNGLE" => Some("jungle".to_string()),
+        "MIDDLE" | "MID" => Some("mid".to_string()),
+        "BOTTOM" | "BOT" | "ADC" => Some("bot".to_string()),
+        "UTILITY" | "SUPPORT" | "SUP" => Some("support".to_string()),
+        _ => None,
+    }
+}
 
 pub async fn start_watcher(handle: AppHandle) {
     loop {
@@ -22,8 +45,8 @@ pub async fn start_watcher(handle: AppHandle) {
                 }
                 let _ = handle.emit("lcu-status",
                     serde_json::json!({ "connected": false }));
-                // Champion Select 終了時にリセット
                 LAST_CHAMP.store(0, Ordering::Relaxed);
+                LAST_LANE.store(0, Ordering::Relaxed);
             }
             Err(_) => {}
         }
@@ -60,7 +83,6 @@ async fn run_ws(
     ).await?;
     let (mut write, mut read) = ws.split();
 
-    // Champion Select セッションを購読
     write.send(Message::Text(
         serde_json::json!([5, "OnJsonApiEvent_lol-champ-select_v1_session"])
             .to_string().into()
@@ -81,53 +103,59 @@ async fn run_ws(
 }
 
 async fn handle_event(event: &Value, client: &LcuClient, handle: &AppHandle) {
-    // イベント形式: [8, "OnJsonApiEvent_...", { eventType, uri, data }]
     let data = match event.get(2).and_then(|v| v.get("data")) {
         Some(d) => d,
         None => return,
     };
 
-    // localPlayerCellId で自分のセルを特定（サモナーID取得不要）
     let my_cell_id = match data.get("localPlayerCellId").and_then(|v| v.as_i64()) {
         Some(id) => id,
         None => return,
     };
 
-    // myTeam と theirTeam 両方から自分のセルを探す
-    let champ_id = find_champ_in_team(data, "myTeam", my_cell_id)
-        .or_else(|| find_champ_in_team(data, "theirTeam", my_cell_id))
-        .unwrap_or(0);
+    let result = find_champ_in_team(data, "myTeam", my_cell_id)
+        .or_else(|| find_champ_in_team(data, "theirTeam", my_cell_id));
+
+    let (champ_id, lane) = match result {
+        Some(r) => r,
+        None => (0, None),
+    };
 
     if champ_id == 0 {
-        // キャラ未選択（ホバー前）
-        // IDが0に戻った = Champion Select を出た
         if LAST_CHAMP.load(Ordering::Relaxed) != 0 {
             LAST_CHAMP.store(0, Ordering::Relaxed);
+            LAST_LANE.store(0, Ordering::Relaxed);
             let _ = handle.emit("champion-cleared", serde_json::json!({}));
         }
         return;
     }
 
-    // 同じキャラが連続で来た場合はスキップ
-    let last = LAST_CHAMP.swap(champ_id, Ordering::Relaxed);
-    if last == champ_id {
+    let lane_id = lane_to_id(lane.as_deref());
+    let last_champ = LAST_CHAMP.load(Ordering::Relaxed);
+    let last_lane = LAST_LANE.load(Ordering::Relaxed);
+
+    if last_champ == champ_id && last_lane == lane_id {
         return;
     }
 
-    log::info!("Champion changed: {} -> {}", last, champ_id);
+    LAST_CHAMP.store(champ_id, Ordering::Relaxed);
+    LAST_LANE.store(lane_id, Ordering::Relaxed);
 
-    // フロントに通知
-    let _ = handle.emit("champion-changed",
-        serde_json::json!({ "championId": champ_id }));
+    log::info!("Champion changed: {}:{:?} -> {}:{:?}", last_champ, last_lane, champ_id, lane);
 
-    // 保存済みルーンがあれば自動適用
-    if let Some(runes) = get_saved_runes(handle, champ_id) {
-        log::info!("Auto-applying runes for champion={}", champ_id);
+    let _ = handle.emit("champion-changed", serde_json::json!({
+        "championId": champ_id,
+        "lane": lane,
+    }));
+
+    if let Some(runes) = get_saved_runes(handle, champ_id, lane.as_deref()) {
+        log::info!("Auto-applying runes for champion={} lane={:?}", champ_id, lane);
         match apply_champion_runes(client, &runes).await {
             Ok(_) => {
                 let _ = handle.emit("runes-applied", serde_json::json!({
                     "championId": champ_id,
                     "championName": runes.champion_name,
+                    "lane": runes.lane,
                     "pageCount": runes.pages.len(),
                 }));
             }
@@ -139,24 +167,25 @@ async fn handle_event(event: &Value, client: &LcuClient, handle: &AppHandle) {
         }
     } else {
         let _ = handle.emit("runes-not-found",
-            serde_json::json!({ "championId": champ_id }));
+            serde_json::json!({ "championId": champ_id, "lane": lane }));
     }
 }
 
-fn find_champ_in_team(data: &Value, team_key: &str, cell_id: i64) -> Option<i64> {
+fn find_champ_in_team(data: &Value, team_key: &str, cell_id: i64) -> Option<(i64, Option<String>)> {
     let team = data.get(team_key)?.as_array()?;
     let entry = team.iter().find(|e| {
-        e.get("cellId")
-            .and_then(|id| id.as_i64())
-            .map(|id| id == cell_id)
-            .unwrap_or(false)
+        e.get("cellId").and_then(|id| id.as_i64()) == Some(cell_id)
     })?;
 
-    // championId が 0 より大きい場合のみ返す
-    // ホバー中は championId に値が入る
     let champ_id = entry.get("championId")
         .and_then(|id| id.as_i64())
         .unwrap_or(0);
+    if champ_id <= 0 { return None; }
 
-    if champ_id > 0 { Some(champ_id) } else { None }
+    let lane = entry.get("assignedPosition")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .and_then(lcu_position_to_lane);
+
+    Some((champ_id, lane))
 }

--- a/src/App.css
+++ b/src/App.css
@@ -311,3 +311,16 @@ button.btn-share-copy, button.btn-share-parse, button.btn-share-load {
 .btn-share-parse:disabled { opacity: .4; cursor: not-allowed; }
 .btn-share-load  { background: var(--goldd); border-color: var(--gold); color: var(--goldl); flex-shrink: 0; }
 .btn-share-load:hover { background: var(--gold); color: #090910; }
+/* Lane Select */
+.lane-select{display:flex;gap:4px;margin-bottom:12px;padding:8px;background:var(--bg2);border-radius:var(--r);border:1px solid var(--bd)}
+.lane-btn{display:flex;flex-direction:column;align-items:center;gap:2px;flex:1;padding:6px 4px;background:var(--bg3);border:1px solid var(--bd);border-radius:4px;cursor:pointer;transition:all .13s;position:relative;color:var(--tx2)}
+.lane-btn:hover{border-color:var(--bdb);color:var(--tx)}
+.lane-btn.active{border-color:var(--gold);background:rgba(200,155,60,.12);color:var(--goldl)}
+.lane-btn.saved{border-color:var(--ok)}
+.lane-btn.active.saved{border-color:var(--gold)}
+.lane-icon{font-size:14px;line-height:1}
+.lane-label{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.5px}
+.lane-saved-dot{position:absolute;top:3px;right:3px;width:5px;height:5px;border-radius:50%;background:var(--ok)}
+
+/* ChampSelectPanel lane badge */
+.cs-lane-badge{display:inline-block;padding:1px 6px;background:rgba(200,155,60,.2);color:var(--goldl);border-radius:3px;font-size:10px;font-weight:600;margin-right:4px}

--- a/src/components/ChampSelectPanel.tsx
+++ b/src/components/ChampSelectPanel.tsx
@@ -3,12 +3,14 @@ import { listen } from "@tauri-apps/api/event";
 import { applyRunesManually, getChampionRunes } from "../hooks/useLcu";
 import { useDataDragonContext } from "../contexts/DataDragonContext";
 import { useLcuContext } from "../contexts/LcuContext";
-import type { ChampionRunes } from "../types";
+import type { ChampionRunes, Lane } from "../types";
+import { LANES } from "../types";
 
 export function ChampSelectPanel() {
   const { getChampionById, champIconUrl } = useDataDragonContext();
   const { connected: lcuConnected } = useLcuContext();
   const [championId, setChampionId] = useState<number | null>(null);
+  const [detectedLane, setDetectedLane] = useState<Lane | null>(null);
   const [runes, setRunes] = useState<ChampionRunes | null>(null);
   const [applying, setApplying] = useState(false);
   const [lastResult, setLastResult] = useState<"ok" | "err" | null>(null);
@@ -16,20 +18,24 @@ export function ChampSelectPanel() {
 
   useEffect(() => {
     const unlistens = Promise.all([
-      listen<{ championId: number }>("champion-changed", async (e) => {
+      listen<{ championId: number; lane?: Lane }>("champion-changed", async (e) => {
         const id = e.payload.championId;
+        const lane = e.payload.lane ?? null;
         setChampionId(id);
+        setDetectedLane(lane);
         setLastResult(null);
         setErrMsg("");
-        const saved = await getChampionRunes(id).catch(() => null);
+        // レーンあり → 完全一致で検索、なければフォールバックはバックエンドが担当
+        const saved = await getChampionRunes(id, lane).catch(() => null);
         setRunes(saved);
       }),
       listen("champion-cleared", () => {
         setChampionId(null);
+        setDetectedLane(null);
         setRunes(null);
         setLastResult(null);
       }),
-      listen("runes-applied", () => {
+      listen<{ lane?: Lane }>("runes-applied", () => {
         setLastResult("ok");
         setApplying(false);
       }),
@@ -47,7 +53,7 @@ export function ChampSelectPanel() {
     setApplying(true);
     setLastResult(null);
     try {
-      await applyRunesManually(championId);
+      await applyRunesManually(championId, detectedLane);
       setLastResult("ok");
     } catch (e) {
       setErrMsg(String(e));
@@ -58,6 +64,9 @@ export function ChampSelectPanel() {
   };
 
   const champion = championId ? getChampionById(championId) : null;
+  const laneLabel = detectedLane
+    ? LANES.find((l) => l.value === detectedLane)?.label ?? detectedLane
+    : null;
 
   if (!lcuConnected) {
     return (
@@ -87,9 +96,10 @@ export function ChampSelectPanel() {
         <div className="cs-champ-info">
           <div className="cs-champ-name">{champion?.name ?? `ID: ${championId}`}</div>
           <div className="cs-champ-sub">
+            {laneLabel && <span className="cs-lane-badge">{laneLabel}</span>}
             {runes
-              ? `${runes.pages.length} page${runes.pages.length > 1 ? "s" : ""} registered`
-              : "No runes registered"}
+              ? ` ${runes.pages.length} page${runes.pages.length > 1 ? "s" : ""} registered`
+              : " No runes registered"}
           </div>
         </div>
         {lastResult === "ok" && (
@@ -126,7 +136,10 @@ export function ChampSelectPanel() {
         </button>
       ) : (
         <div className="cs-no-runes">
-          このチャンピオンのルーンが未登録です。<br />
+          {laneLabel
+            ? `${champion?.name ?? ""} (${laneLabel}) のルーンが未登録です。`
+            : `このチャンピオンのルーンが未登録です。`}
+          <br />
           Editorタブで登録してください。
         </div>
       )}

--- a/src/components/ChampionSelect.tsx
+++ b/src/components/ChampionSelect.tsx
@@ -8,7 +8,14 @@ export function ChampionSelect() {
   const { savedRunes, selectedChampion, setSelectedChampion } = useChampionContext();
   const [search, setSearch] = useState("");
 
-  const savedIds = useMemo(() => new Set(savedRunes.map((r) => r.championId)), [savedRunes]);
+  // チャンピオンIDごとの登録レーン数
+  const savedLaneCounts = useMemo(() => {
+    const counts = new Map<number, number>();
+    for (const r of savedRunes) {
+      counts.set(r.championId, (counts.get(r.championId) ?? 0) + 1);
+    }
+    return counts;
+  }, [savedRunes]);
 
   const filtered = useMemo(
     () => champions.filter((c) =>
@@ -18,8 +25,8 @@ export function ChampionSelect() {
     [champions, search]
   );
 
-  const savedChamps = !search ? champions.filter((c) => savedIds.has(parseInt(c.key))) : [];
-  const restChamps = filtered.filter((c) => search || !savedIds.has(parseInt(c.key)));
+  const savedChamps = !search ? champions.filter((c) => savedLaneCounts.has(parseInt(c.key))) : [];
+  const restChamps = filtered.filter((c) => search || !savedLaneCounts.has(parseInt(c.key)));
 
   return (
     <div className="champ-select">
@@ -34,7 +41,9 @@ export function ChampionSelect() {
           <div className="champ-grid">
             {savedChamps.map((c) => (
               <ChampCard key={c.key} champ={c} url={champIconUrl(c)}
-                selected={selectedChampion?.key === c.key} saved onClick={() => setSelectedChampion(c)} />
+                selected={selectedChampion?.key === c.key}
+                laneCount={savedLaneCounts.get(parseInt(c.key)) ?? 0}
+                onClick={() => setSelectedChampion(c)} />
             ))}
           </div>
           <div className="section-label">All Champions</div>
@@ -43,7 +52,8 @@ export function ChampionSelect() {
       <div className="champ-grid">
         {restChamps.map((c) => (
           <ChampCard key={c.key} champ={c} url={champIconUrl(c)}
-            selected={selectedChampion?.key === c.key} saved={savedIds.has(parseInt(c.key))}
+            selected={selectedChampion?.key === c.key}
+            laneCount={savedLaneCounts.get(parseInt(c.key)) ?? 0}
             onClick={() => setSelectedChampion(c)} />
         ))}
       </div>
@@ -52,13 +62,17 @@ export function ChampionSelect() {
   );
 }
 
-function ChampCard({ champ, url, selected, saved, onClick }: {
-  champ: Champion; url: string; selected: boolean; saved: boolean; onClick: () => void;
+function ChampCard({ champ, url, selected, laneCount, onClick }: {
+  champ: Champion; url: string; selected: boolean; laneCount: number; onClick: () => void;
 }) {
   return (
     <button className={`champ-card ${selected ? "selected" : ""}`} onClick={onClick} title={champ.name}>
       <img src={url} alt={champ.name} />
-      {saved && <span className="saved-badge">v</span>}
+      {laneCount > 0 && (
+        <span className="saved-badge" title={`${laneCount} lane${laneCount > 1 ? "s" : ""} registered`}>
+          {laneCount}
+        </span>
+      )}
       <span className="champ-name">{champ.name}</span>
     </button>
   );

--- a/src/components/LaneSelect.tsx
+++ b/src/components/LaneSelect.tsx
@@ -1,0 +1,44 @@
+import type { Lane, ChampionRunes } from "../types";
+import { LANES } from "../types";
+
+interface LaneSelectProps {
+  selected: Lane | null;
+  onChange: (lane: Lane) => void;
+  savedRunes?: ChampionRunes[];
+  championId?: number;
+}
+
+export function LaneSelect({ selected, onChange, savedRunes, championId }: LaneSelectProps) {
+  const savedLanes = new Set(
+    savedRunes
+      ?.filter((r) => r.championId === championId && r.lane != null)
+      .map((r) => r.lane as Lane) ?? []
+  );
+
+  return (
+    <div className="lane-select">
+      {LANES.map(({ value, label }) => (
+        <button
+          key={value}
+          className={`lane-btn ${selected === value ? "active" : ""} ${savedLanes.has(value) ? "saved" : ""}`}
+          onClick={() => onChange(value)}
+          title={label}
+        >
+          <span className="lane-icon">{getLaneIcon(value)}</span>
+          <span className="lane-label">{label}</span>
+          {savedLanes.has(value) && <span className="lane-saved-dot" />}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function getLaneIcon(lane: Lane): string {
+  switch (lane) {
+    case "top": return "⬆";
+    case "jungle": return "✦";
+    case "mid": return "◆";
+    case "bot": return "⬇";
+    case "support": return "♡";
+  }
+}

--- a/src/components/RuneEditor.tsx
+++ b/src/components/RuneEditor.tsx
@@ -4,6 +4,7 @@ import { useChampionContext } from "../contexts/ChampionContext";
 import type { RunePage, ChampionRunes } from "../types";
 import { RuneTreeSelector } from "./RuneTreeSelector";
 import { RuneSharePanel } from "./RuneSharePanel";
+import { LaneSelect } from "./LaneSelect";
 import { saveChampionRunes, getChampionRunes, deleteChampionRunes, applyRunesManually } from "../hooks/useLcu";
 
 const blank = (): Partial<RunePage> => ({
@@ -12,15 +13,15 @@ const blank = (): Partial<RunePage> => ({
 
 export function RuneEditor() {
   const { runeStyles, runeIconUrl, champIconUrl } = useDataDragonContext();
-  const { selectedChampion: champion, refreshSaved } = useChampionContext();
+  const { selectedChampion: champion, selectedLane: lane, setSelectedLane, savedRunes, refreshSaved } = useChampionContext();
   const [tab, setTab] = useState(0);
   const [pages, setPages] = useState<Partial<RunePage>[]>([blank(), blank(), blank()]);
   const [status, setStatus] = useState<"idle"|"saving"|"saved"|"applying">("idle");
   const [msg, setMsg] = useState("");
 
   useEffect(() => {
-    if (!champion) { setPages([blank(), blank(), blank()]); return; }
-    getChampionRunes(parseInt(champion.key)).then((data) => {
+    if (!champion || !lane) { setPages([blank(), blank(), blank()]); return; }
+    getChampionRunes(parseInt(champion.key), lane).then((data) => {
       if (data) {
         const loaded = [blank(), blank(), blank()];
         data.pages.forEach((p, i) => { if (i < 3) loaded[i] = p; });
@@ -29,7 +30,7 @@ export function RuneEditor() {
         setPages([blank(), blank(), blank()]);
       }
     });
-  }, [champion]);
+  }, [champion, lane]);
 
   const updatePage = useCallback((i: number, page: Partial<RunePage>) => {
     setPages((prev) => { const n = [...prev]; n[i] = page; return n; });
@@ -38,7 +39,7 @@ export function RuneEditor() {
   const flash = (m: string) => { setMsg(m); setTimeout(() => setMsg(""), 3000); };
 
   const handleSave = async () => {
-    if (!champion) return;
+    if (!champion || !lane) return;
     const valid = pages.filter(
       (p) => p.primaryStyleId && p.subStyleId &&
         (p.selectedPerkIds?.filter((id) => id > 0).length ?? 0) >= 6
@@ -49,7 +50,8 @@ export function RuneEditor() {
       const runes: ChampionRunes = {
         championId: parseInt(champion.key),
         championName: champion.name,
-        pages: valid.map((p, i) => ({ ...p, name: p.name || `${champion.name} - Page ${i + 1}` })),
+        lane,
+        pages: valid.map((p, i) => ({ ...p, name: p.name || `${champion.name} ${lane.toUpperCase()} - Page ${i + 1}` })),
       };
       await saveChampionRunes(runes);
       setStatus("saved");
@@ -60,9 +62,9 @@ export function RuneEditor() {
   };
 
   const handleDelete = async () => {
-    if (!champion || !confirm(`Delete runes for ${champion.name}?`)) return;
+    if (!champion || !lane || !confirm(`Delete runes for ${champion.name} (${lane.toUpperCase()})?`)) return;
     try {
-      await deleteChampionRunes(parseInt(champion.key));
+      await deleteChampionRunes(parseInt(champion.key), lane);
       setPages([blank(), blank(), blank()]);
       flash("Deleted");
       refreshSaved();
@@ -70,10 +72,10 @@ export function RuneEditor() {
   };
 
   const handleApply = async () => {
-    if (!champion) return;
+    if (!champion || !lane) return;
     setStatus("applying");
     try {
-      await applyRunesManually(parseInt(champion.key));
+      await applyRunesManually(parseInt(champion.key), lane);
       flash("Applied to LoL!");
     } catch (e) { flash(`Apply failed: ${e}`); }
     setStatus("idle");
@@ -96,43 +98,60 @@ export function RuneEditor() {
         <img className="champ-portrait" src={champIconUrl(champion)} alt={champion.name} />
         <div>
           <h2 className="champ-title">{champion.name}</h2>
-          <div className="champ-sub">Rune pages (max 3)</div>
+          <div className="champ-sub">
+            {lane ? `${lane.toUpperCase()} — Rune pages (max 3)` : "Select a lane"}
+          </div>
         </div>
-        <div className="editor-btns">
-          <button className="btn-apply" onClick={handleApply} disabled={status === "applying"}>
-            {status === "applying" ? "Applying..." : "Apply Now"}
-          </button>
-          <button className="btn-del" onClick={handleDelete}>Delete</button>
-          <button className={`btn-save ${status === "saved" ? "saved" : ""}`}
-            onClick={handleSave} disabled={status === "saving"}>
-            {status === "saving" ? "Saving..." : status === "saved" ? "Saved!" : "Save"}
-          </button>
-        </div>
+        {lane && (
+          <div className="editor-btns">
+            <button className="btn-apply" onClick={handleApply} disabled={status === "applying"}>
+              {status === "applying" ? "Applying..." : "Apply Now"}
+            </button>
+            <button className="btn-del" onClick={handleDelete}>Delete</button>
+            <button className={`btn-save ${status === "saved" ? "saved" : ""}`}
+              onClick={handleSave} disabled={status === "saving"}>
+              {status === "saving" ? "Saving..." : status === "saved" ? "Saved!" : "Save"}
+            </button>
+          </div>
+        )}
       </div>
-      {msg && <div className="editor-msg">{msg}</div>}
-      <div className="page-tabs">
-        {[0, 1, 2].map((i) => (
-          <button key={i}
-            className={`page-tab ${tab === i ? "active" : ""} ${hasData(pages[i]) ? "has-data" : ""}`}
-            onClick={() => setTab(i)}>
-            {pages[i].name || `Page ${i + 1}`}
-            {hasData(pages[i]) && <span className="tab-dot" />}
-          </button>
-        ))}
-      </div>
-      <div className="page-name-bar">
-        <input className="page-name-in" type="text"
-          placeholder={`Page name (e.g. ${champion.name} Tank)`}
-          value={cur.name ?? ""}
-          onChange={(e) => updatePage(tab, { ...cur, name: e.target.value })}
-          maxLength={30} />
-      </div>
-      <RuneTreeSelector runeStyles={runeStyles} runeIconUrl={runeIconUrl}
-        value={cur} onChange={(p) => updatePage(tab, p)} />
-      <RuneSharePanel
-        currentPage={cur}
-        onImport={(p) => updatePage(tab, { ...cur, ...p })}
+
+      <LaneSelect
+        selected={lane}
+        onChange={setSelectedLane}
+        savedRunes={savedRunes}
+        championId={parseInt(champion.key)}
       />
+
+      {msg && <div className="editor-msg">{msg}</div>}
+
+      {lane && (
+        <>
+          <div className="page-tabs">
+            {[0, 1, 2].map((i) => (
+              <button key={i}
+                className={`page-tab ${tab === i ? "active" : ""} ${hasData(pages[i]) ? "has-data" : ""}`}
+                onClick={() => setTab(i)}>
+                {pages[i].name || `Page ${i + 1}`}
+                {hasData(pages[i]) && <span className="tab-dot" />}
+              </button>
+            ))}
+          </div>
+          <div className="page-name-bar">
+            <input className="page-name-in" type="text"
+              placeholder={`Page name (e.g. ${champion.name} ${lane.toUpperCase()} Tank)`}
+              value={cur.name ?? ""}
+              onChange={(e) => updatePage(tab, { ...cur, name: e.target.value })}
+              maxLength={30} />
+          </div>
+          <RuneTreeSelector runeStyles={runeStyles} runeIconUrl={runeIconUrl}
+            value={cur} onChange={(p) => updatePage(tab, p)} />
+          <RuneSharePanel
+            currentPage={cur}
+            onImport={(p) => updatePage(tab, { ...cur, ...p })}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/contexts/ChampionContext.tsx
+++ b/src/contexts/ChampionContext.tsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
 import type { Champion } from "../hooks/useDataDragon";
-import type { ChampionRunes } from "../types";
+import type { ChampionRunes, Lane } from "../types";
 import { getAllChampionRunes } from "../hooks/useLcu";
 
 interface ChampionContextValue {
   selectedChampion: Champion | null;
   setSelectedChampion: (c: Champion | null) => void;
+  selectedLane: Lane | null;
+  setSelectedLane: (lane: Lane | null) => void;
   savedRunes: ChampionRunes[];
   refreshSaved: () => void;
 }
@@ -13,8 +15,14 @@ interface ChampionContextValue {
 const ChampionContext = createContext<ChampionContextValue | null>(null);
 
 export function ChampionProvider({ children }: { children: ReactNode }) {
-  const [selectedChampion, setSelectedChampion] = useState<Champion | null>(null);
+  const [selectedChampion, setSelectedChampionRaw] = useState<Champion | null>(null);
+  const [selectedLane, setSelectedLane] = useState<Lane | null>(null);
   const [savedRunes, setSavedRunes] = useState<ChampionRunes[]>([]);
+
+  const setSelectedChampion = useCallback((c: Champion | null) => {
+    setSelectedChampionRaw(c);
+    setSelectedLane(null);
+  }, []);
 
   const refreshSaved = useCallback(
     () => getAllChampionRunes().then(setSavedRunes).catch(() => {}),
@@ -24,7 +32,11 @@ export function ChampionProvider({ children }: { children: ReactNode }) {
   useEffect(() => { refreshSaved(); }, []);
 
   return (
-    <ChampionContext.Provider value={{ selectedChampion, setSelectedChampion, savedRunes, refreshSaved }}>
+    <ChampionContext.Provider value={{
+      selectedChampion, setSelectedChampion,
+      selectedLane, setSelectedLane,
+      savedRunes, refreshSaved,
+    }}>
       {children}
     </ChampionContext.Provider>
   );

--- a/src/hooks/useLcu.ts
+++ b/src/hooks/useLcu.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { LcuStatus, ChampionRunes, LcuRunePage } from "../types";
+import type { LcuStatus, ChampionRunes, LcuRunePage, Lane } from "../types";
 
 export function useLcuStatus() {
   const [status, setStatus] = useState<LcuStatus>({ connected: false });
@@ -17,14 +17,16 @@ export function useLcuStatus() {
 }
 
 export function useChampionSelectWatcher(
-  onChampionChanged: (id: number) => void,
-  onRunesApplied: (info: { championId: number; championName: string; pageCount: number }) => void,
+  onChampionChanged: (id: number, lane: Lane | null) => void,
+  onRunesApplied: (info: { championId: number; championName: string; lane?: Lane; pageCount: number }) => void,
   onRunesError: (err: string) => void
 ) {
   useEffect(() => {
     const uns = Promise.all([
-      listen<{ championId: number }>("champion-changed", (e) => onChampionChanged(e.payload.championId)),
-      listen<{ championId: number; championName: string; pageCount: number }>("runes-applied", (e) => onRunesApplied(e.payload)),
+      listen<{ championId: number; lane?: Lane }>("champion-changed", (e) =>
+        onChampionChanged(e.payload.championId, e.payload.lane ?? null)),
+      listen<{ championId: number; championName: string; lane?: Lane; pageCount: number }>("runes-applied", (e) =>
+        onRunesApplied(e.payload)),
       listen<{ error: string }>("runes-error", (e) => onRunesError(e.payload.error)),
     ]);
     return () => { uns.then((fns) => fns.forEach((f) => f())); };
@@ -34,17 +36,17 @@ export function useChampionSelectWatcher(
 export const saveChampionRunes = (runes: ChampionRunes) =>
   invoke<void>("save_champion_runes", { championRunes: runes });
 
-export const getChampionRunes = (championId: number) =>
-  invoke<ChampionRunes | null>("get_champion_runes", { championId });
+export const getChampionRunes = (championId: number, lane?: Lane | null) =>
+  invoke<ChampionRunes | null>("get_champion_runes", { championId, lane: lane ?? null });
 
 export const getAllChampionRunes = () =>
   invoke<ChampionRunes[]>("get_all_champion_runes");
 
-export const deleteChampionRunes = (championId: number) =>
-  invoke<void>("delete_champion_runes", { championId });
+export const deleteChampionRunes = (championId: number, lane?: Lane | null) =>
+  invoke<void>("delete_champion_runes", { championId, lane: lane ?? null });
 
-export const applyRunesManually = (championId: number) =>
-  invoke<void>("apply_runes_manually", { championId });
+export const applyRunesManually = (championId: number, lane?: Lane | null) =>
+  invoke<void>("apply_runes_manually", { championId, lane: lane ?? null });
 
 export const getCurrentRunePages = () =>
   invoke<LcuRunePage[]>("get_current_rune_pages");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,9 +5,20 @@
   selectedPerkIds: number[];
 }
 
+export type Lane = "top" | "jungle" | "mid" | "bot" | "support";
+
+export const LANES: { value: Lane; label: string; abbr: string }[] = [
+  { value: "top", label: "Top", abbr: "TOP" },
+  { value: "jungle", label: "Jungle", abbr: "JGL" },
+  { value: "mid", label: "Mid", abbr: "MID" },
+  { value: "bot", label: "Bot", abbr: "BOT" },
+  { value: "support", label: "Support", abbr: "SUP" },
+];
+
 export interface ChampionRunes {
   championId: number;
   championName: string;
+  lane?: Lane;
   pages: RunePage[];
 }
 


### PR DESCRIPTION
チャンピオンのルーンセットをレーン（ポジション）ごとに保存・取得できるよう機能を拡張します。同一チャンピオンで複数レーンを使い分けるケース（例: ナーを TOP と JG で異なるルーンで使う）に対応します。 

- ChampionRunesにlaneフィールド追加（既存データはlane=nullで後方互換）
- save/get/delete/applyコマンドをchampionId+lane複合キー対応に変更
- LCUセッションからassignedPositionを取得しレーンを自動検知
- レーン未登録時のフォールバック（チャンピオンのみで検索）
- LaneSelectコンポーネントとレーン選択UI追加
- ChampionSelectのsavedバッジをレーン数表示に変更
- ChampSelectPanelにレーンバッジ表示追加

UIのLiveには未対応。ブラインドピックやランダムミッド時もエラーかな。別issueに。