### PR TITLE
feat: キャラ+レーン別アイテムセット管理

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -112,7 +112,7 @@ pub async fn apply_runes_manually(
     let runes = get_saved_runes(&app, champion_id, lane.as_deref())
         .ok_or_else(|| format!("No runes for champion {}", champion_id))?;
     apply_champion_runes(&client, &runes).await.map_err(|e| e.to_string())?;
-    let _ = apply_champion_item_sets(&client, &runes).await;
+    apply_champion_item_sets(&client, &runes).await.map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 
 use crate::lcu::{
     client::LcuClient,
+    items::apply_champion_item_sets,
     runes::{apply_champion_runes, get_rune_pages, ChampionRunes, LcuRunePage},
 };
 
@@ -110,5 +111,19 @@ pub async fn apply_runes_manually(
     let client = LcuClient::from_lockfile().map_err(|e| e.to_string())?;
     let runes = get_saved_runes(&app, champion_id, lane.as_deref())
         .ok_or_else(|| format!("No runes for champion {}", champion_id))?;
-    apply_champion_runes(&client, &runes).await.map_err(|e| e.to_string())
+    apply_champion_runes(&client, &runes).await.map_err(|e| e.to_string())?;
+    let _ = apply_champion_item_sets(&client, &runes).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn apply_item_sets_manually(
+    app: AppHandle,
+    champion_id: i64,
+    lane: Option<String>,
+) -> Result<(), String> {
+    let client = LcuClient::from_lockfile().map_err(|e| e.to_string())?;
+    let runes = get_saved_runes(&app, champion_id, lane.as_deref())
+        .ok_or_else(|| format!("No runes for champion {}", champion_id))?;
+    apply_champion_item_sets(&client, &runes).await.map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lcu/client.rs
+++ b/src-tauri/src/lcu/client.rs
@@ -109,6 +109,23 @@ impl LcuClient {
         Ok(serde_json::from_str(&text)?)
     }
 
+    pub async fn put(&self, path: &str, body: &Value) -> Result<Value, LcuError> {
+        let resp = self.client
+            .put(format!("{}{}", self.base_url(), path))
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(body).send().await?;
+        let status = resp.status().as_u16();
+        let text = resp.text().await?;
+        if status >= 400 {
+            return Err(LcuError::Api { status, body: text });
+        }
+        if text.is_empty() {
+            return Ok(serde_json::Value::Null);
+        }
+        Ok(serde_json::from_str(&text)?)
+    }
+
     pub async fn delete(&self, path: &str) -> Result<(), LcuError> {
         let resp = self.client
             .delete(format!("{}{}", self.base_url(), path))

--- a/src-tauri/src/lcu/items.rs
+++ b/src-tauri/src/lcu/items.rs
@@ -1,3 +1,4 @@
+use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 use super::client::{LcuClient, LcuError};
 use super::runes::ChampionRunes;
@@ -9,13 +10,26 @@ async fn get_summoner_id(client: &LcuClient) -> Result<i64, LcuError> {
         .ok_or_else(|| LcuError::Api { status: 0, body: "No summonerId".into() })
 }
 
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
 pub async fn apply_champion_item_sets(
     client: &LcuClient,
     runes: &ChampionRunes,
 ) -> Result<(), LcuError> {
     let champion_id = runes.champion_id;
+
+    // アイテムが1つ以上あるページのみ対象
     let pages_with_items: Vec<_> = runes.pages.iter()
-        .filter(|p| p.item_set.as_ref().map(|s| !s.blocks.is_empty()).unwrap_or(false))
+        .filter(|p| {
+            p.item_set.as_ref().map(|s| {
+                s.blocks.iter().any(|b| !b.items.is_empty())
+            }).unwrap_or(false)
+        })
         .collect();
 
     if pages_with_items.is_empty() {
@@ -23,6 +37,7 @@ pub async fn apply_champion_item_sets(
     }
 
     let summoner_id = get_summoner_id(client).await?;
+
     let existing = client
         .get(&format!("/lol-item-sets/v1/item-sets/{}/sets", summoner_id))
         .await
@@ -34,7 +49,7 @@ pub async fn apply_champion_item_sets(
         .cloned()
         .unwrap_or_default();
 
-    // Remove existing item sets for this champion
+    // このチャンピオンの既存アイテムセットを削除
     sets.retain(|s| {
         s.get("associatedChampions")
             .and_then(|v| v.as_array())
@@ -42,27 +57,37 @@ pub async fn apply_champion_item_sets(
             .unwrap_or(true)
     });
 
-    // Add new item sets from each rune page
-    for page in pages_with_items {
+    let ts = now_ms();
+
+    for (idx, page) in pages_with_items.iter().enumerate() {
         let item_set = page.item_set.as_ref().unwrap();
-        let blocks: Vec<Value> = item_set.blocks.iter().map(|b| {
-            json!({
+
+        let blocks: Vec<Value> = item_set.blocks.iter()
+            .filter(|b| !b.items.is_empty())
+            .map(|b| json!({
                 "type": b.block_type,
                 "items": b.items.iter().map(|i| {
                     json!({ "id": i.id.to_string(), "count": i.count })
                 }).collect::<Vec<_>>()
-            })
-        }).collect();
+            }))
+            .collect();
 
+        // LCU APIに必要なフィールドをすべて含める
         sets.push(json!({
+            "uid": format!("{}-{}-{}", ts, champion_id, idx),
             "title": &page.name,
+            "type": "custom",
+            "map": "any",
+            "mode": "any",
+            "priority": false,
+            "sortrank": 0,
             "associatedChampions": [champion_id],
             "associatedMaps": [11, 12, 21],
             "blocks": blocks,
         }));
     }
 
-    let payload = json!({ "itemSets": sets, "timestamp": 0 });
+    let payload = json!({ "itemSets": sets, "timestamp": ts });
     client.put(
         &format!("/lol-item-sets/v1/item-sets/{}/sets", summoner_id),
         &payload,

--- a/src-tauri/src/lcu/items.rs
+++ b/src-tauri/src/lcu/items.rs
@@ -1,0 +1,72 @@
+use serde_json::{json, Value};
+use super::client::{LcuClient, LcuError};
+use super::runes::ChampionRunes;
+
+async fn get_summoner_id(client: &LcuClient) -> Result<i64, LcuError> {
+    let summoner = client.get("/lol-summoner/v1/current-summoner").await?;
+    summoner.get("summonerId")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| LcuError::Api { status: 0, body: "No summonerId".into() })
+}
+
+pub async fn apply_champion_item_sets(
+    client: &LcuClient,
+    runes: &ChampionRunes,
+) -> Result<(), LcuError> {
+    let champion_id = runes.champion_id;
+    let pages_with_items: Vec<_> = runes.pages.iter()
+        .filter(|p| p.item_set.as_ref().map(|s| !s.blocks.is_empty()).unwrap_or(false))
+        .collect();
+
+    if pages_with_items.is_empty() {
+        return Ok(());
+    }
+
+    let summoner_id = get_summoner_id(client).await?;
+    let existing = client
+        .get(&format!("/lol-item-sets/v1/item-sets/{}/sets", summoner_id))
+        .await
+        .unwrap_or_else(|_| json!({ "itemSets": [], "timestamp": 0 }));
+
+    let mut sets: Vec<Value> = existing
+        .get("itemSets")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    // Remove existing item sets for this champion
+    sets.retain(|s| {
+        s.get("associatedChampions")
+            .and_then(|v| v.as_array())
+            .map(|arr| !arr.iter().any(|id| id.as_i64() == Some(champion_id)))
+            .unwrap_or(true)
+    });
+
+    // Add new item sets from each rune page
+    for page in pages_with_items {
+        let item_set = page.item_set.as_ref().unwrap();
+        let blocks: Vec<Value> = item_set.blocks.iter().map(|b| {
+            json!({
+                "type": b.block_type,
+                "items": b.items.iter().map(|i| {
+                    json!({ "id": i.id.to_string(), "count": i.count })
+                }).collect::<Vec<_>>()
+            })
+        }).collect();
+
+        sets.push(json!({
+            "title": &page.name,
+            "associatedChampions": [champion_id],
+            "associatedMaps": [11, 12, 21],
+            "blocks": blocks,
+        }));
+    }
+
+    let payload = json!({ "itemSets": sets, "timestamp": 0 });
+    client.put(
+        &format!("/lol-item-sets/v1/item-sets/{}/sets", summoner_id),
+        &payload,
+    ).await?;
+
+    Ok(())
+}

--- a/src-tauri/src/lcu/mod.rs
+++ b/src-tauri/src/lcu/mod.rs
@@ -1,3 +1,4 @@
 ﻿pub mod client;
+pub mod items;
 pub mod runes;
 pub mod watcher;

--- a/src-tauri/src/lcu/runes.rs
+++ b/src-tauri/src/lcu/runes.rs
@@ -3,6 +3,24 @@ use serde_json::json;
 use super::client::{LcuClient, LcuError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemEntry {
+    pub id: i64,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemBlock {
+    #[serde(rename = "type")]
+    pub block_type: String,
+    pub items: Vec<ItemEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemSet {
+    pub blocks: Vec<ItemBlock>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunePage {
     pub name: String,
     #[serde(rename = "primaryStyleId")]
@@ -11,6 +29,8 @@ pub struct RunePage {
     pub sub_style_id: i64,
     #[serde(rename = "selectedPerkIds")]
     pub selected_perk_ids: Vec<i64>,
+    #[serde(rename = "itemSet", default)]
+    pub item_set: Option<ItemSet>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lcu/watcher.rs
+++ b/src-tauri/src/lcu/watcher.rs
@@ -5,6 +5,7 @@ use tauri::{AppHandle, Emitter};
 use tokio_tungstenite::{connect_async_tls_with_config, tungstenite::Message, Connector};
 
 use super::client::LcuClient;
+use super::items::apply_champion_item_sets;
 use super::runes::apply_champion_runes;
 use crate::commands::get_saved_runes;
 
@@ -179,6 +180,7 @@ async fn handle_event(event: &Value, client: &LcuClient, handle: &AppHandle) {
                     "lane": runes.lane,
                     "pageCount": runes.pages.len(),
                 }));
+                let _ = apply_champion_item_sets(client, &runes).await;
             }
             Err(e) => {
                 log::error!("Failed to apply runes: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
             commands::get_all_champion_runes,
             commands::delete_champion_runes,
             commands::apply_runes_manually,
+            commands::apply_item_sets_manually,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.css
+++ b/src/App.css
@@ -324,3 +324,54 @@ button.btn-share-copy, button.btn-share-parse, button.btn-share-load {
 
 /* ChampSelectPanel lane badge */
 .cs-lane-badge{display:inline-block;padding:1px 6px;background:rgba(200,155,60,.2);color:var(--goldl);border-radius:3px;font-size:10px;font-weight:600;margin-right:4px}
+
+/* ── ItemSetEditor ── */
+.itemset-editor{margin-top:16px}
+.itemset-toggle{width:100%;display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--bg2);border:1px solid var(--bd);border-radius:var(--r);cursor:pointer;transition:border-color .13s;color:var(--tx2)}
+.itemset-toggle:hover{border-color:var(--bdb);color:var(--tx)}
+.itemset-toggle-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.6px}
+.itemset-badge{margin-left:4px;padding:1px 7px;background:rgba(74,127,212,.15);border:1px solid var(--inf);border-radius:10px;font-size:10px;color:#7eb8f7}
+.itemset-arrow{margin-left:auto;font-size:10px;color:var(--txm)}
+.itemset-body{margin-top:4px;padding:12px;background:var(--bg2);border:1px solid var(--bd);border-radius:var(--r);display:flex;flex-direction:column;gap:10px}
+.itemset-block-tabs{display:flex;flex-wrap:wrap;gap:4px;align-items:center}
+.itemset-block-tab{display:flex;align-items:center;gap:2px;position:relative}
+.itemset-block-tab-btn{padding:4px 10px;background:var(--bg3);border:1px solid var(--bd);border-radius:4px;color:var(--tx2);font-size:11px;cursor:pointer;transition:all .12s;white-space:nowrap}
+.itemset-block-tab-btn:hover{border-color:var(--bdb);color:var(--tx)}
+.itemset-block-tab.active .itemset-block-tab-btn{border-color:var(--gold);color:var(--goldl);background:rgba(200,155,60,.1)}
+.itemset-block-count{margin-left:4px;font-size:9px;color:var(--txm)}
+.itemset-block-remove{width:14px;height:14px;display:flex;align-items:center;justify-content:center;background:none;border:none;color:var(--txm);cursor:pointer;font-size:10px;padding:0;margin-left:1px;border-radius:2px}
+.itemset-block-remove:hover{color:var(--err)}
+.itemset-block-add{padding:3px 8px;background:none;border:1px dashed var(--bd);border-radius:4px;color:var(--txm);cursor:pointer;font-size:13px;line-height:1;transition:all .12s}
+.itemset-block-add:hover{border-color:var(--bdb);color:var(--tx)}
+.itemset-block-name-in{padding:3px 7px;background:var(--bg3);border:1px solid var(--gold);border-radius:4px;color:var(--tx);font-size:11px;outline:none;width:90px}
+.itemset-current-items{display:flex;flex-wrap:wrap;gap:4px;min-height:44px;padding:6px;background:var(--bg3);border:1px solid var(--bd);border-radius:var(--r)}
+.itemset-empty-hint{font-size:11px;color:var(--txm);align-self:center;width:100%;text-align:center}
+.itemset-slot{position:relative;width:40px;height:40px;border-radius:4px;border:1px solid var(--bd);overflow:hidden;cursor:pointer;transition:border-color .12s}
+.itemset-slot:hover{border-color:var(--err)}
+.itemset-slot img{width:100%;height:100%;object-fit:cover}
+.itemset-slot-count{position:absolute;bottom:1px;right:2px;font-size:9px;font-weight:700;color:#fff;text-shadow:0 0 3px #000}
+.itemset-divider{height:1px;background:var(--bd)}
+.itemset-search-row{display:flex;align-items:center;gap:6px}
+.itemset-search{flex:1;padding:6px 10px;background:var(--bg3);border:1px solid var(--bd);border-radius:var(--r);color:var(--tx);font-size:12px;outline:none;transition:border-color .13s}
+.itemset-search:focus{border-color:var(--bdb)}
+.itemset-search::placeholder{color:var(--txm)}
+.itemset-search-clear{background:none;border:none;color:var(--txm);cursor:pointer;font-size:14px;padding:0 4px}
+.itemset-search-clear:hover{color:var(--tx)}
+.itemset-tags{display:flex;flex-wrap:wrap;gap:4px}
+.itemset-tag{padding:3px 8px;background:var(--bg3);border:1px solid var(--bd);border-radius:10px;color:var(--tx2);font-size:10px;cursor:pointer;transition:all .12s;white-space:nowrap}
+.itemset-tag:hover{border-color:var(--bdb);color:var(--tx)}
+.itemset-tag.active{background:rgba(200,155,60,.15);border-color:var(--gold);color:var(--goldl)}
+.itemset-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(36px,1fr));gap:3px;max-height:200px;overflow-y:auto}
+.itemset-item-btn{width:36px;height:36px;padding:0;background:var(--bg3);border:1px solid var(--bd);border-radius:3px;cursor:pointer;overflow:hidden;transition:border-color .1s}
+.itemset-item-btn:hover{border-color:var(--gold)}
+.itemset-item-btn img{width:100%;height:100%;object-fit:cover;display:block}
+.itemset-clear{padding:5px 12px;background:transparent;border:1px solid var(--bd);border-radius:var(--r);color:var(--txm);font-size:11px;cursor:pointer;transition:all .13s;margin-top:2px}
+.itemset-clear:hover{border-color:var(--err);color:var(--err)}
+
+/* ── RuneSharePanel export list ── */
+.share-export-list{display:flex;flex-direction:column;gap:6px}
+.share-export-tag{display:inline-block;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:600;flex-shrink:0;min-width:38px;text-align:center}
+.share-export-tag.rune{background:rgba(200,155,60,.15);color:var(--goldl)}
+.share-export-tag.item{background:rgba(74,127,212,.12);color:#7eb8f7}
+.share-export-tag.combined{background:rgba(61,170,106,.12);color:#6fcf97}
+.share-tree.item-preview{background:rgba(74,127,212,.1);color:#7eb8f7}

--- a/src/components/ItemSetEditor.tsx
+++ b/src/components/ItemSetEditor.tsx
@@ -197,7 +197,7 @@ export function ItemSetEditor({ value, onChange }: Props) {
 
           {/* Item grid */}
           <div className="itemset-grid">
-            {filteredItems.slice(0, 120).map((item) => (
+            {filteredItems.map((item) => (
               <button
                 key={item.id}
                 className="itemset-item-btn"

--- a/src/components/ItemSetEditor.tsx
+++ b/src/components/ItemSetEditor.tsx
@@ -1,0 +1,222 @@
+import { useState, useMemo } from "react";
+import { useDataDragonContext } from "../contexts/DataDragonContext";
+import type { ItemSet, ItemBlock, DDItem } from "../types";
+
+const DEFAULT_BLOCKS = ["Starting", "Core", "Situational"];
+
+function emptySet(): ItemSet {
+  return { blocks: DEFAULT_BLOCKS.map((type) => ({ type, items: [] })) };
+}
+
+interface Props {
+  value: ItemSet | undefined;
+  onChange: (set: ItemSet | undefined) => void;
+}
+
+export function ItemSetEditor({ value, onChange }: Props) {
+  const { items, itemIconUrl } = useDataDragonContext();
+  const [open, setOpen] = useState(false);
+  const [blockIdx, setBlockIdx] = useState(0);
+  const [search, setSearch] = useState("");
+  const [tagFilter, setTagFilter] = useState("");
+  const [editingName, setEditingName] = useState<number | null>(null);
+  const [editNameVal, setEditNameVal] = useState("");
+
+  const set = value ?? emptySet();
+
+  const update = (next: ItemSet) => onChange(next);
+
+  const curBlock: ItemBlock = set.blocks[blockIdx] ?? { type: "", items: [] };
+
+  const filteredItems = useMemo(() => {
+    const q = search.toLowerCase();
+    return items.filter((item) => {
+      if (tagFilter && !item.tags.includes(tagFilter)) return false;
+      if (q && !item.name.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [items, search, tagFilter]);
+
+  const addItem = (item: DDItem) => {
+    const blocks = set.blocks.map((b, i) => {
+      if (i !== blockIdx) return b;
+      const existing = b.items.find((e) => e.id === item.id);
+      if (existing) {
+        return { ...b, items: b.items.map((e) => e.id === item.id ? { ...e, count: e.count + 1 } : e) };
+      }
+      return { ...b, items: [...b.items, { id: item.id, count: 1 }] };
+    });
+    update({ ...set, blocks });
+  };
+
+  const removeItem = (itemId: number) => {
+    const blocks = set.blocks.map((b, i) =>
+      i !== blockIdx ? b : { ...b, items: b.items.filter((e) => e.id !== itemId) }
+    );
+    update({ ...set, blocks });
+  };
+
+  const addBlock = () => {
+    const newBlock: ItemBlock = { type: `Block ${set.blocks.length + 1}`, items: [] };
+    update({ ...set, blocks: [...set.blocks, newBlock] });
+    setBlockIdx(set.blocks.length);
+  };
+
+  const removeBlock = (idx: number) => {
+    if (set.blocks.length <= 1) return;
+    const blocks = set.blocks.filter((_, i) => i !== idx);
+    update({ ...set, blocks });
+    setBlockIdx(Math.min(blockIdx, blocks.length - 1));
+  };
+
+  const renameBlock = (idx: number, name: string) => {
+    const blocks = set.blocks.map((b, i) => i === idx ? { ...b, type: name } : b);
+    update({ ...set, blocks });
+  };
+
+  const getItem = (id: number) => items.find((i) => i.id === id);
+
+  const TAGS = [
+    { label: "全て", value: "" },
+    { label: "Boots", value: "Boots" },
+    { label: "Damage", value: "Damage" },
+    { label: "AP", value: "SpellDamage" },
+    { label: "Crit", value: "CriticalStrike" },
+    { label: "HP", value: "Health" },
+    { label: "Armor", value: "Armor" },
+    { label: "MR", value: "SpellBlock" },
+    { label: "AS", value: "AttackSpeed" },
+    { label: "Mana", value: "Mana" },
+    { label: "AH", value: "AbilityHaste" },
+    { label: "Jungle", value: "Jungle" },
+    { label: "消耗品", value: "Consumable" },
+  ];
+
+  return (
+    <div className="itemset-editor">
+      <button className="itemset-toggle" onClick={() => setOpen((v) => !v)}>
+        <span className="itemset-toggle-label">Item Set</span>
+        {value && value.blocks.some((b) => b.items.length > 0) && (
+          <span className="itemset-badge">
+            {value.blocks.reduce((s, b) => s + b.items.length, 0)} items
+          </span>
+        )}
+        <span className="itemset-arrow">{open ? "▲" : "▼"}</span>
+      </button>
+
+      {open && (
+        <div className="itemset-body">
+          {/* Block tabs */}
+          <div className="itemset-block-tabs">
+            {set.blocks.map((b, i) => (
+              <div key={i} className={`itemset-block-tab ${blockIdx === i ? "active" : ""}`}>
+                {editingName === i ? (
+                  <input
+                    className="itemset-block-name-in"
+                    value={editNameVal}
+                    autoFocus
+                    onChange={(e) => setEditNameVal(e.target.value)}
+                    onBlur={() => {
+                      if (editNameVal.trim()) renameBlock(i, editNameVal.trim());
+                      setEditingName(null);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        if (editNameVal.trim()) renameBlock(i, editNameVal.trim());
+                        setEditingName(null);
+                      } else if (e.key === "Escape") {
+                        setEditingName(null);
+                      }
+                    }}
+                  />
+                ) : (
+                  <button
+                    className="itemset-block-tab-btn"
+                    onClick={() => setBlockIdx(i)}
+                    onDoubleClick={() => { setEditNameVal(b.type); setEditingName(i); }}
+                  >
+                    {b.type}
+                    {b.items.length > 0 && <span className="itemset-block-count">{b.items.length}</span>}
+                  </button>
+                )}
+                {set.blocks.length > 1 && (
+                  <button className="itemset-block-remove" onClick={(e) => { e.stopPropagation(); removeBlock(i); }}>×</button>
+                )}
+              </div>
+            ))}
+            {set.blocks.length < 8 && (
+              <button className="itemset-block-add" onClick={addBlock}>+</button>
+            )}
+          </div>
+
+          {/* Current block items */}
+          <div className="itemset-current-items">
+            {curBlock.items.length === 0 ? (
+              <span className="itemset-empty-hint">下のグリッドからアイテムを追加</span>
+            ) : (
+              curBlock.items.map((entry) => {
+                const item = getItem(entry.id);
+                if (!item) return null;
+                return (
+                  <div key={entry.id} className="itemset-slot" title={item.name} onClick={() => removeItem(entry.id)}>
+                    <img src={itemIconUrl(item)} alt={item.name} />
+                    {entry.count > 1 && <span className="itemset-slot-count">{entry.count}</span>}
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="itemset-divider" />
+
+          {/* Search + tag filter */}
+          <div className="itemset-search-row">
+            <input
+              className="itemset-search"
+              type="text"
+              placeholder="アイテム検索..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            {search && (
+              <button className="itemset-search-clear" onClick={() => setSearch("")}>×</button>
+            )}
+          </div>
+          <div className="itemset-tags">
+            {TAGS.map((t) => (
+              <button
+                key={t.value}
+                className={`itemset-tag ${tagFilter === t.value ? "active" : ""}`}
+                onClick={() => setTagFilter(t.value === tagFilter ? "" : t.value)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Item grid */}
+          <div className="itemset-grid">
+            {filteredItems.slice(0, 120).map((item) => (
+              <button
+                key={item.id}
+                className="itemset-item-btn"
+                title={`${item.name} (${item.gold.total}g)`}
+                onClick={() => addItem(item)}
+              >
+                <img src={itemIconUrl(item)} alt={item.name} loading="lazy" />
+              </button>
+            ))}
+          </div>
+
+          {/* Clear button */}
+          {value && value.blocks.some((b) => b.items.length > 0) && (
+            <button className="itemset-clear" onClick={() => onChange(undefined)}>
+              アイテムセットをクリア
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/RuneEditor.tsx
+++ b/src/components/RuneEditor.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { useDataDragonContext } from "../contexts/DataDragonContext";
 import { useChampionContext } from "../contexts/ChampionContext";
-import type { RunePage, ChampionRunes } from "../types";
+import type { RunePage, ChampionRunes, ItemSet } from "../types";
 import { RuneTreeSelector } from "./RuneTreeSelector";
 import { RuneSharePanel } from "./RuneSharePanel";
+import { ItemSetEditor } from "./ItemSetEditor";
 import { LaneSelect } from "./LaneSelect";
 import { saveChampionRunes, getChampionRunes, deleteChampionRunes, applyRunesManually } from "../hooks/useLcu";
 
@@ -146,6 +147,10 @@ export function RuneEditor() {
           </div>
           <RuneTreeSelector runeStyles={runeStyles} runeIconUrl={runeIconUrl}
             value={cur} onChange={(p) => updatePage(tab, p)} />
+          <ItemSetEditor
+            value={cur.itemSet}
+            onChange={(set: ItemSet | undefined) => updatePage(tab, { ...cur, itemSet: set })}
+          />
           <RuneSharePanel
             currentPage={cur}
             onImport={(p) => updatePage(tab, { ...cur, ...p })}

--- a/src/components/RuneSharePanel.tsx
+++ b/src/components/RuneSharePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import type { RunePage } from "../types";
+import type { RunePage, ItemSet } from "../types";
 import { encodeRunePage, decodeRunePage } from "../utils/runeCode";
+import { encodeItemSet, decodeItemSet, encodeCombined, decodeCombined, detectCodeType } from "../utils/itemSetCode";
 import { useDataDragonContext } from "../contexts/DataDragonContext";
 
 interface Props {
@@ -8,67 +9,115 @@ interface Props {
   onImport: (page: Partial<RunePage>) => void;
 }
 
+type PreviewData =
+  | { type: "rune"; page: Partial<RunePage> }
+  | { type: "itemset"; set: ItemSet }
+  | { type: "combined"; page: Partial<RunePage>; set: ItemSet };
+
 export function RuneSharePanel({ currentPage, onImport }: Props) {
   const { runeStyles } = useDataDragonContext();
   const [importCode, setImportCode] = useState("");
-  const [preview, setPreview] = useState<Partial<RunePage> | null>(null);
+  const [preview, setPreview] = useState<PreviewData | null>(null);
   const [parseError, setParseError] = useState("");
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<"rune" | "item" | "combined" | null>(null);
 
-  const hasCurrentPage = !!currentPage.primaryStyleId;
-  const exportCode = hasCurrentPage ? encodeRunePage(currentPage) : "";
+  const hasRune = !!currentPage.primaryStyleId;
+  const hasItemSet = !!(currentPage.itemSet?.blocks.some((b) => b.items.length > 0));
+
+  const runeCode = hasRune ? encodeRunePage(currentPage) : "";
+  const itemCode = hasItemSet ? encodeItemSet(currentPage.itemSet!) : "";
+  const combinedCode = hasRune && hasItemSet ? encodeCombined(runeCode, itemCode) : "";
 
   const styleName = (id: number) => runeStyles.find((s) => s.id === id)?.name ?? `Style ${id}`;
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(exportCode);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async (code: string, kind: "rune" | "item" | "combined") => {
+    await navigator.clipboard.writeText(code);
+    setCopied(kind);
+    setTimeout(() => setCopied(null), 2000);
   };
 
   const handleParse = () => {
     if (!importCode.trim()) return;
+    setParseError("");
+    setPreview(null);
     try {
-      setPreview(decodeRunePage(importCode));
-      setParseError("");
+      const kind = detectCodeType(importCode.trim());
+      if (kind === "rune") {
+        setPreview({ type: "rune", page: decodeRunePage(importCode.trim()) });
+      } else if (kind === "itemset") {
+        setPreview({ type: "itemset", set: decodeItemSet(importCode.trim()) });
+      } else if (kind === "combined") {
+        const { runeCode: rc, itemCode: ic } = decodeCombined(importCode.trim());
+        const page = rc ? decodeRunePage(rc) : {};
+        const set = ic ? decodeItemSet(ic) : { blocks: [] };
+        setPreview({ type: "combined", page, set });
+      } else {
+        setParseError("不明なコード形式です");
+      }
     } catch (e) {
       setParseError(String(e));
-      setPreview(null);
     }
   };
 
   const handleLoad = () => {
     if (!preview) return;
-    onImport(preview);
+    if (preview.type === "rune") {
+      onImport(preview.page);
+    } else if (preview.type === "itemset") {
+      onImport({ ...currentPage, itemSet: preview.set });
+    } else if (preview.type === "combined") {
+      onImport({ ...preview.page, itemSet: preview.set });
+    }
     setImportCode("");
     setPreview(null);
   };
 
   return (
     <div className="share-panel">
-      {/* Export */}
       <div className="share-section">
         <span className="share-label">Export</span>
-        {hasCurrentPage ? (
-          <div className="share-export-row">
-            <code className="share-code">{exportCode}</code>
-            <button className="btn-share-copy" onClick={handleCopy}>
-              {copied ? "Copied!" : "Copy"}
-            </button>
-          </div>
+        {!hasRune && !hasItemSet ? (
+          <span className="share-hint">ルーンまたはアイテムセットを設定するとコードが生成されます</span>
         ) : (
-          <span className="share-hint">ルーンを選択するとコードが生成されます</span>
+          <div className="share-export-list">
+            {hasRune && (
+              <div className="share-export-row">
+                <span className="share-export-tag rune">Rune</span>
+                <code className="share-code">{runeCode}</code>
+                <button className="btn-share-copy" onClick={() => handleCopy(runeCode, "rune")}>
+                  {copied === "rune" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            )}
+            {hasItemSet && (
+              <div className="share-export-row">
+                <span className="share-export-tag item">Item</span>
+                <code className="share-code">{itemCode}</code>
+                <button className="btn-share-copy" onClick={() => handleCopy(itemCode, "item")}>
+                  {copied === "item" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            )}
+            {hasRune && hasItemSet && (
+              <div className="share-export-row">
+                <span className="share-export-tag combined">Full</span>
+                <code className="share-code">{combinedCode}</code>
+                <button className="btn-share-copy" onClick={() => handleCopy(combinedCode, "combined")}>
+                  {copied === "combined" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            )}
+          </div>
         )}
       </div>
 
-      {/* Import */}
       <div className="share-section">
         <span className="share-label">Import</span>
         <div className="share-import-row">
           <input
             className="share-input"
             type="text"
-            placeholder="コードを貼り付け..."
+            placeholder="コードを貼り付け... (Rune / Item / Full)"
             value={importCode}
             onChange={(e) => { setImportCode(e.target.value); setPreview(null); setParseError(""); }}
             onKeyDown={(e) => e.key === "Enter" && handleParse()}
@@ -78,17 +127,29 @@ export function RuneSharePanel({ currentPage, onImport }: Props) {
           </button>
         </div>
         {parseError && <div className="share-error">{parseError}</div>}
-        {preview && preview.primaryStyleId && (
+        {preview && (
           <div className="share-preview">
             <div className="share-preview-trees">
-              <span className="share-tree primary">{styleName(preview.primaryStyleId)}</span>
-              {preview.subStyleId && (
+              {(preview.type === "rune" || preview.type === "combined") && preview.page.primaryStyleId && (
                 <>
-                  <span className="share-tree-sep">+</span>
-                  <span className="share-tree sub">{styleName(preview.subStyleId)}</span>
+                  <span className="share-tree primary">{styleName(preview.page.primaryStyleId)}</span>
+                  {preview.page.subStyleId && (
+                    <>
+                      <span className="share-tree-sep">+</span>
+                      <span className="share-tree sub">{styleName(preview.page.subStyleId)}</span>
+                    </>
+                  )}
+                  <span className="share-perk-count">{preview.page.selectedPerkIds?.length ?? 0} perks</span>
                 </>
               )}
-              <span className="share-perk-count">{preview.selectedPerkIds?.length ?? 0} perks</span>
+              {(preview.type === "itemset" || preview.type === "combined") && (
+                <span className="share-tree item-preview">
+                  {(preview as Extract<PreviewData, { set: ItemSet }>).set.blocks
+                    .filter((b) => b.items.length > 0)
+                    .map((b) => `${b.type}(${b.items.length})`)
+                    .join(" / ")}
+                </span>
+              )}
             </div>
             <button className="btn-share-load" onClick={handleLoad}>現在のページに読み込む</button>
           </div>

--- a/src/contexts/DataDragonContext.tsx
+++ b/src/contexts/DataDragonContext.tsx
@@ -1,15 +1,17 @@
 import { createContext, useContext, type ReactNode } from "react";
 import { useDataDragon, type Champion } from "../hooks/useDataDragon";
-import type { PerkStyle } from "../types";
+import type { PerkStyle, DDItem } from "../types";
 
 interface DataDragonContextValue {
   runeStyles: PerkStyle[];
   champions: Champion[];
+  items: DDItem[];
   loading: boolean;
   error: string | null;
   getChampionById: (id: number) => Champion | undefined;
   champIconUrl: (c: Champion) => string;
   runeIconUrl: (icon: string) => string;
+  itemIconUrl: (item: DDItem) => string;
 }
 
 const DataDragonContext = createContext<DataDragonContextValue | null>(null);

--- a/src/hooks/useDataDragon.ts
+++ b/src/hooks/useDataDragon.ts
@@ -41,13 +41,21 @@ export function useDataDragon() {
         list.sort((a, b) => a.name.localeCompare(b.name, "ja"));
         setChampions(list);
 
+        const seen = new Set<string>();
         const itemList: DDItem[] = Object.entries(itemData.data)
           .map(([id, raw]) => ({ id: parseInt(id), ...(raw as Omit<DDItem, "id">) }))
           .filter((item) =>
             item.gold.purchasable &&
+            item.inStore !== false &&
+            !item.hideFromAll &&
             (item.maps["11"] || item.maps["12"])
           )
-          .sort((a, b) => a.gold.total - b.gold.total);
+          .sort((a, b) => a.gold.total - b.gold.total)
+          .filter((item) => {
+            if (seen.has(item.name)) return false;
+            seen.add(item.name);
+            return true;
+          });
         setItems(itemList);
       } catch (e) {
         setError(String(e));

--- a/src/hooks/useDataDragon.ts
+++ b/src/hooks/useDataDragon.ts
@@ -1,5 +1,5 @@
 ﻿import { useState, useEffect } from "react";
-import type { PerkStyle } from "../types";
+import type { PerkStyle, DDItem } from "../types";
 
 const DD_BASE_ROOT = "https://ddragon.leagueoflegends.com";
 
@@ -13,6 +13,7 @@ export interface Champion {
 export function useDataDragon() {
   const [runeStyles, setRuneStyles] = useState<PerkStyle[]>([]);
   const [champions, setChampions] = useState<Champion[]>([]);
+  const [items, setItems] = useState<DDItem[]>([]);
   const [version, setVersion] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -29,15 +30,25 @@ export function useDataDragon() {
 
         const base = `${DD_BASE_ROOT}/cdn/${latest}`;
 
-        const [runeData, champData] = await Promise.all([
+        const [runeData, champData, itemData] = await Promise.all([
           fetch(`${base}/data/ja_JP/runesReforged.json`).then((r) => r.json()),
           fetch(`${base}/data/ja_JP/champion.json`).then((r) => r.json()),
+          fetch(`${base}/data/ja_JP/item.json`).then((r) => r.json()),
         ]);
 
         setRuneStyles(runeData);
         const list: Champion[] = Object.values(champData.data);
         list.sort((a, b) => a.name.localeCompare(b.name, "ja"));
         setChampions(list);
+
+        const itemList: DDItem[] = Object.entries(itemData.data)
+          .map(([id, raw]) => ({ id: parseInt(id), ...(raw as Omit<DDItem, "id">) }))
+          .filter((item) =>
+            item.gold.purchasable &&
+            (item.maps["11"] || item.maps["12"])
+          )
+          .sort((a, b) => a.gold.total - b.gold.total);
+        setItems(itemList);
       } catch (e) {
         setError(String(e));
       } finally {
@@ -56,13 +67,18 @@ export function useDataDragon() {
   const runeIconUrl = (icon: string) =>
     `${DD_BASE_ROOT}/cdn/img/${icon}`;
 
+  const itemIconUrl = (item: DDItem) =>
+    `${DD_BASE_ROOT}/cdn/${version}/img/item/${item.image.full}`;
+
   return {
     runeStyles,
     champions,
+    items,
     loading,
     error,
     getChampionById,
     champIconUrl,
     runeIconUrl,
+    itemIconUrl,
   };
 }

--- a/src/hooks/useLcu.ts
+++ b/src/hooks/useLcu.ts
@@ -50,3 +50,6 @@ export const applyRunesManually = (championId: number, lane?: Lane | null) =>
 
 export const getCurrentRunePages = () =>
   invoke<LcuRunePage[]>("get_current_rune_pages");
+
+export const applyItemSetsManually = (championId: number, lane?: Lane | null) =>
+  invoke<void>("apply_item_sets_manually", { championId, lane: lane ?? null });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,8 @@ export interface DDItem {
   gold: { total: number; purchasable: boolean };
   tags: string[];
   maps: Record<string, boolean>;
+  inStore?: boolean;
+  hideFromAll?: boolean;
 }
 
 export type Lane = "top" | "jungle" | "mid" | "bot" | "support" | "aram" | "other";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,33 @@
-﻿export interface RunePage {
+﻿export interface ItemEntry {
+  id: number;
+  count: number;
+}
+
+export interface ItemBlock {
+  type: string;
+  items: ItemEntry[];
+}
+
+export interface ItemSet {
+  blocks: ItemBlock[];
+}
+
+export interface RunePage {
   name: string;
   primaryStyleId: number;
   subStyleId: number;
   selectedPerkIds: number[];
+  itemSet?: ItemSet;
+}
+
+export interface DDItem {
+  id: number;
+  name: string;
+  plaintext: string;
+  image: { full: string };
+  gold: { total: number; purchasable: boolean };
+  tags: string[];
+  maps: Record<string, boolean>;
 }
 
 export type Lane = "top" | "jungle" | "mid" | "bot" | "support" | "aram" | "other";

--- a/src/utils/itemSetCode.ts
+++ b/src/utils/itemSetCode.ts
@@ -1,0 +1,137 @@
+import type { ItemSet } from "../types";
+
+const VERSION = 2;
+
+// Binary layout (little-endian):
+// [0]     version (uint8) = 2
+// [1]     block count (uint8)
+// for each block:
+//   [N]     type string byte length (uint8)
+//   [N+1..] type string (utf8)
+//   [M]     item count (uint8)
+//   for each item:
+//     [M+1, M+2] item id (uint16)
+//     [M+3]      count   (uint8)
+
+function encodeString(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function decodeString(buf: Uint8Array, offset: number, len: number): string {
+  return new TextDecoder().decode(buf.slice(offset, offset + len));
+}
+
+export function encodeItemSet(set: ItemSet): string {
+  const blocks = set.blocks.filter((b) => b.items.length > 0);
+
+  const parts: Uint8Array[] = [];
+  let totalLen = 2; // version + block count
+
+  for (const block of blocks) {
+    const typeBytes = encodeString(block.type);
+    const typeLen = Math.min(typeBytes.length, 255);
+    totalLen += 1 + typeLen + 1 + block.items.length * 3;
+  }
+
+  const buf = new Uint8Array(totalLen);
+  const view = new DataView(buf.buffer);
+  let off = 0;
+
+  view.setUint8(off++, VERSION);
+  view.setUint8(off++, Math.min(blocks.length, 255));
+
+  for (const block of blocks) {
+    const typeBytes = encodeString(block.type);
+    const typeLen = Math.min(typeBytes.length, 255);
+    view.setUint8(off++, typeLen);
+    buf.set(typeBytes.slice(0, typeLen), off);
+    off += typeLen;
+
+    const items = block.items.slice(0, 255);
+    view.setUint8(off++, items.length);
+    for (const item of items) {
+      view.setUint16(off, item.id, true); off += 2;
+      view.setUint8(off++, Math.min(item.count, 255));
+    }
+  }
+
+  void parts;
+  return btoa(String.fromCharCode(...buf))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function decodeItemSet(code: string): ItemSet {
+  const b64 = code.trim().replace(/-/g, "+").replace(/_/g, "/");
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new Error("Invalid code format");
+  }
+
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+
+  if (buf.length < 2) throw new Error("Code too short");
+
+  const view = new DataView(buf.buffer);
+  let off = 0;
+
+  const version = view.getUint8(off++);
+  if (version !== VERSION) throw new Error(`Unsupported version: ${version}`);
+
+  const blockCount = view.getUint8(off++);
+  const blocks = [];
+
+  for (let b = 0; b < blockCount; b++) {
+    if (off >= buf.length) throw new Error("Code truncated");
+    const typeLen = view.getUint8(off++);
+    if (off + typeLen > buf.length) throw new Error("Code truncated");
+    const type = decodeString(buf, off, typeLen);
+    off += typeLen;
+
+    const itemCount = view.getUint8(off++);
+    const items = [];
+    for (let i = 0; i < itemCount; i++) {
+      if (off + 3 > buf.length) throw new Error("Code truncated");
+      const id = view.getUint16(off, true); off += 2;
+      const count = view.getUint8(off++);
+      items.push({ id, count });
+    }
+    blocks.push({ type, items });
+  }
+
+  return { blocks };
+}
+
+export type CombinedCodeParts = {
+  runeCode: string | null;
+  itemCode: string | null;
+};
+
+export function encodeCombined(runeCode: string, itemCode: string): string {
+  return `${runeCode}|${itemCode}`;
+}
+
+export function decodeCombined(code: string): CombinedCodeParts {
+  const idx = code.indexOf("|");
+  if (idx === -1) return { runeCode: null, itemCode: null };
+  return {
+    runeCode: code.slice(0, idx) || null,
+    itemCode: code.slice(idx + 1) || null,
+  };
+}
+
+export function detectCodeType(code: string): "rune" | "itemset" | "combined" | "unknown" {
+  if (code.includes("|")) return "combined";
+  try {
+    const b64 = code.trim().replace(/-/g, "+").replace(/_/g, "/");
+    const bin = atob(b64);
+    const version = bin.charCodeAt(0);
+    if (version === 1) return "rune";
+    if (version === 2) return "itemset";
+  } catch {
+    // ignore
+  }
+  return "unknown";
+}


### PR DESCRIPTION
ルーンページにアイテムセットを紐づけ、保存・共有・自動適用できる機能を追加

- アイテムセットのデータ構造を追加（ルーンに紐づけ可能）
- アイテム選択UIを実装（検索・フィルター・ブロック編集）
- LCU連携でルーンとアイテムセットを同時に自動適用
- アイテムセットの共有コード対応（ルーンと統合エクスポート/インポート）